### PR TITLE
Fix references to parquet; restructure

### DIFF
--- a/.github/workflows/publish_dockers.yml
+++ b/.github/workflows/publish_dockers.yml
@@ -33,7 +33,7 @@ jobs:
           file: ./share/docker/Dockerfile
           push: false
           target: core
-          tags: infispiel/darshan_util_dxtthread:latest
+          tags: infispiel/wfmeta_darshan_util_dxtthread:latest
 
       - name: Build and push development Docker image
         id: build_dev
@@ -42,4 +42,4 @@ jobs:
           context: ./share/docker
           file: ./share/docker/Dockerfile
           push: false
-          tags: infispiel/darshan_util_dxtthread_dev:latest
+          tags: infispiel/wfmeta_darshan_util_dxtthread_dev:latest

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ ex_darshan_logs
 XPDaMoDa
 parquet/
 parquet2/
+__pycache__

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,23 @@
 [project]
-name = "pydarshan-dask-tests"
+name = "wfmeta-darshan"
 version = "0.1.0"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.8"
 dependencies = [
     "darshan>=3.4.5.0",
+    #"darshan @ git+https://github.com/darshan-hpc/darshan@snyder/dxt-extra-info-pthread-id#egg=darshan&subdirectory=darshan-util/pydarshan",
     "ipykernel>=6.29.5",
     "pyarrow>=17.0.0",
     "pandas",
+]
+
+[dependency-groups]
+dev = [
+    "pytest>=8.3.5",
+]
+
+[tool.pytest.ini_options]
+pythonpath= [
+    "src"
 ]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,0 @@
-[pytest]
-testpaths =
-    tests

--- a/src/wfmeta_darshan/__init__.py
+++ b/src/wfmeta_darshan/__init__.py
@@ -1,202 +1,22 @@
-from typing import Dict, List, Tuple
+from typing import Any, Dict, List
 from functools import reduce
 import darshan
 import os
-import argparse
 import pandas as pd
 
-#####################################################
-# Classes                                           #
-#####################################################
-
-##############################
-# counter-only collections   #
-##############################
-
-class counters_coll :
-    report_name: str
-    report_ids: Dict[str, str]
-    metadata: List[Tuple[int, int]]
-    records: Dict[Tuple[int, int], pd.DataFrame]
-    collapsed: pd.DataFrame
-    module_name: str = "ERR"
-
-    def __init__(self, records, report_name, report_ids) :
-        self.report_name = report_name
-        self.report_ids = report_ids
-        self.metadata = []
-        self.records = {}
-
-        for record in records :
-            record_metadata = (record["rank"], record["id"])
-            # if record_metadata[0] != record["counters"].rank[0] and record_metadata[0] != -1 :
-            #     raise ValueError("Rank of record does not match rank in provided DF.")
-            # if record_metadata[1] != record["counters"].id[0] and record_metadata[1] != -1 :
-            #     raise ValueError("ID of record does not match rank in provided DF.")
-
-            self.metadata.append(record_metadata)
-            self.records[record_metadata] = record["counters"]
-        
-        self._collapse_rank_id()
-    
-    def _collapse_rank_id(self) :
-        output_df: pd.DataFrame = None
-        for i,record in enumerate(self.metadata) :
-            if i == 0 :
-                output_df = self.records[record]
-            else :
-                output_df = pd.concat([output_df, self.records[record]])
-
-        self.collapsed = output_df
-
-    def __add__(self, other: 'counters_coll') -> 'CounterCollColl' :
-        return CounterCollColl(self, other)
-
-class LUSTRE_coll(counters_coll) :
-    module_name: str = "LUSTRE"
-
-    def __init__(self, *args) :
-        super().__init__(*args)
-
-    def export_parquet(self, directory: str, prefix: str) :
-        super().export_parquet("LUSTRE", directory, prefix)
-
-##############################
-# two-dataframe      colls   #
-##############################
-
-# e.g. counters & fcounter
-#      DXT_POSIX (read/write)
-
-class fcounters_coll(counters_coll) :
-    module_name: str = "ERR_fcounters"
-    def __init__(self, records, report_name, report_ids):
-        self.report_name = report_name
-        self.report_ids = report_ids
-        # doesn't use super, might want to change it to use it but
-        #   then we're looping over records twice and that's mildly annoying
-        self.metadata = []
-        self.records = {}
-
-        for record in records :
-            record_metadata = (record["rank"], record["id"])
-            self.metadata.append(record_metadata)
-
-            combined: pd.DataFrame = pd.merge(
-                record["counters"], record["fcounters"], "left",
-                ["id","rank"])
-
-            self.records[record_metadata] = combined
-        
-        self._collapse_rank_id()
-
-class STDIO_coll(fcounters_coll) :
-    module_name:str = "STDIO"
-    def __init__(self, *args) :
-        super().__init__(*args)
-
-    def export_parquet(self, directory: str, prefix: str) :
-        super().export_parquet("STDIO", directory, prefix)
-
-class POSIX_coll(fcounters_coll) :
-    module_name:str = "POSIX"
-    def __init__(self, *args) :
-        super().__init__(*args)
-
-    def export_parquet(self, directory: str, prefix: str) :
-        super().export_parquet("POSIX", directory, prefix)
-
-class DXT_POSIX_coll(fcounters_coll) :
-    module_name:str = "DXT_POSIX"
-    def __init__(self, records, report_name, report_ids) :
-        self.report_name = report_name
-        self.report_ids = report_ids
-        self.metadata = []
-        self.records= {}
-
-        for record in records :
-            record_metadata = (record["rank"], str(record["id"]), record["hostname"],
-                                record["write_count"], record["read_count"])
-            self.metadata.append(record_metadata)
-
-            r_df: pd.DataFrame = record['read_segments'].assign(seg_type="read")
-            w_df: pd.DataFrame = record['write_segments'].assign(seg_type="write")
-
-            rw_df: pd.DataFrame = pd.concat([r_df, w_df]).assign(rank=record["rank"], id=str(record["id"]))
-            self.records[record_metadata] = rw_df
-
-        self._collapse_rank_id()
-
-##############################
-# collection collections     #
-##############################
-
-# e.g. collections of collected module information
-#   i.e. sum of all POSIX collections from all records
-#   separates them by their job uid and jobid.
-
-class CounterCollColl :
-    _type: type
-    module_name: str
-    collection: pd.DataFrame
-
-    def __init__(self, left: counters_coll, right: counters_coll) :
-        if type(left) is not type(right) :
-            raise ValueError("Attempted to combine a %s and a %s." % 
-                             (str(type(left)), str(type(right))))
-        
-        self._type = type(left)
-        self.module_name = left.module_name
-        l_df: pd.DataFrame = left.collapsed
-        l_ids = left.report_ids
-        r_df: pd.DataFrame = right.collapsed
-        r_ids = right.report_ids
-
-        # add ids info as columns
-        l_df = l_df.assign(juid=l_ids['juid'], jobid=l_ids['jobid'])
-        r_df = r_df.assign(juid=r_ids['juid'], jobid=r_ids['jobid'])
-
-        self.collection = pd.concat([l_df,r_df])
-
-    def _file_fillers (self, module_name: str):
-        file_prefix = module_name
-        file_suffix = ".parquet"
-        return (file_prefix, file_suffix)
-
-    def export_parquet(self, directory: str, ltype: str = "counters") :
-        file_prefix, file_suffix = self._file_fillers(self.module_name)
-
-        filename = "%s_%s%s" % (file_prefix, ltype, file_suffix)
-        self.collection.to_parquet(os.path.join(directory, filename))
-
-    def __add__(self, other: counters_coll) :
-        if type(other) is not self._type :
-            raise ValueError("Attempted to add a %s to a %s collection" %
-            (str(type(other)), str(self._type)))
-        
-        r_df: pd.DataFrame = other.collapsed
-        r_ids = other.report_ids
-        r_df = r_df.assign(juid=r_ids['juid'], jobid=r_ids['jobid'])
-
-        self.collection = pd.concat([self.collection,r_df])
-        return self
-
-
+from .objs.colls import POSIX_coll, LUSTRE_coll, DXT_POSIX_coll, STDIO_coll, CounterCollColl
 
 #####################################################
 # Main functions                                    #
 #####################################################
 
-def read_log(filename:str, debug:bool = False) -> List[Dict]:
+def read_log(filename:str, debug:bool = False) -> Dict:
     """Read the provided `.darshan` log file.
     
     Manually reads in the provided `.darshan` log file by loading in its
     core report data, then manually importing each module it sees.
-    Importantly, it does not import any `DXT` modules or the `HEATMAP`
-    module.
+    Importantly, it does not import the `HEATMAP` module.
 
-    This function skips the `DXT` modules because the use case it was
-    developed in would seg fault on any attempt to read these modules.
     It skips the `HEATPMAP` module because the `pydarshan` package
     itself states: 
     ```
@@ -312,6 +132,10 @@ def collect_logfiles(directory:str, debug:bool = False) -> List[str]:
     if debug :
         print("\tFound %i .darshan log files." % len(logfiles))
 
+    if len(logfiles) == 0:
+        print("No darshan log files found in provided directory!")
+        exit(1)
+
     return logfiles
 
 def move_metadata_into_dataframe(report_data: Dict[str, Dict], debug: bool = False) -> pd.DataFrame:
@@ -358,7 +182,8 @@ def move_metadata_into_dataframe(report_data: Dict[str, Dict], debug: bool = Fal
         # Add to dataframe.
         metadata_df.loc[report_name] = values
     
-    if debug : print(metadata_df)
+    if debug:
+        print(metadata_df)
 
     # Return dataframe containing all report metadata.
     return(metadata_df)
@@ -371,16 +196,19 @@ def write_to_parquet(report_data: Dict[str, Dict],
         raise ValueError("Provided directory %s exists and is not a directory. Aborting." % output_dir)
 
     elif os.path.exists(output_dir) :
-        if debug : print("Path exists and is a directory. Proceeding.")
+        if debug:
+            print("Path exists and is a directory. Proceeding.")
 
     elif not os.path.exists(output_dir) :
-        if debug : print("Provided directory does not exist. Creating.")
+        if debug:
+            print("Provided directory does not exist. Creating.")
         os.mkdir(output_dir)
 
     metadata_df_filename = os.path.join(output_dir, "metadata.parquet")
     metadata_df.to_parquet(metadata_df_filename)
 
-    if debug: print("Metadata df written to %s." % metadata_df_filename)
+    if debug:
+        print("Metadata df written to %s." % metadata_df_filename)
 
     # tmp_keys = list(report_data.keys())
     # print(tmp_keys[0])
@@ -397,7 +225,7 @@ def write_to_parquet(report_data: Dict[str, Dict],
     # print(b.collection['jobid'].unique())
     # exit(0)
 
-    all_modules: Dict[str, any] = {}
+    all_modules: Dict[str, Any] = {}
 
     for report_name in list(report_data.keys()) :
         report: Dict = report_data[report_name]
@@ -415,7 +243,8 @@ def write_to_parquet(report_data: Dict[str, Dict],
         res: CounterCollColl = reduce(lambda x,y: x+y, all_modules[module])
         res.export_parquet(output_dir)
 
-    if debug: print("Done writing parquet files!")
+    if debug:
+        print("Done writing parquet files!")
 
 def aggregate_darshan(directory:str, output_loc:str, debug:bool = False) :
     '''Runs the darshan log aggregation process.
@@ -427,21 +256,25 @@ def aggregate_darshan(directory:str, output_loc:str, debug:bool = False) :
     files: List[str] = collect_logfiles(directory, debug)
     collected_report_data: Dict[str, Dict] = {}
 
-    if debug : print("Beginning to collect log data...")
+    if debug:
+        print("Beginning to collect log data...")
 
     for f in files :
         tmp_report_data = read_log(os.path.join(directory, f), debug=debug)
         collected_report_data[tmp_report_data["report_name"]] = tmp_report_data
     
-    if debug : print("Done collecting data!")
+    if debug:
+        print("Done collecting data!")
 
-    if debug : print("Collecting metadata into a dataframe...")
+    if debug:
+        print("Collecting metadata into a dataframe...")
 
     metadata_df: pd.DataFrame = move_metadata_into_dataframe(collected_report_data, debug)
 
-    if debug : print("Done collecting metadata!")
+    if debug:
+        print("Done collecting metadata!")
 
-    write_to_parquet(collected_report_data, metadata_df, output_loc, debug)
+    # write_to_parquet(collected_report_data, metadata_df, output_loc, debug)
 
     # TODO : perform some statistics.
     #           e.g. how many of each type of module is present
@@ -450,15 +283,3 @@ def aggregate_darshan(directory:str, output_loc:str, debug:bool = False) :
     # TODO : output in some format
     
     # write_to_json(output_loc, collected_report_data, debug)
-
-if __name__ == "__main__":
-    parser = argparse.ArgumentParser()
-    parser.add_argument("directory",
-                        help="Relative directory containing the darshan logs to parse and aggregate.")
-    parser.add_argument("-d", "--debug", action="store_true",
-                        help="If true, prints additional debug messages during runtime.")
-    parser.add_argument("--output", default="parquet/",
-                        help="Where to write the JSON dump of the aggregated DARSHAN logs.")
-    args = parser.parse_args()
-
-    aggregate_darshan(args.directory, args.output, args.debug)

--- a/src/wfmeta_darshan/__main__.py
+++ b/src/wfmeta_darshan/__main__.py
@@ -1,0 +1,14 @@
+import argparse
+from wfmeta_darshan import aggregate_darshan
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("directory",
+                        help="Relative directory containing the darshan logs to parse and aggregate.")
+    parser.add_argument("-d", "--debug", action="store_true",
+                        help="If true, prints additional debug messages during runtime.")
+    parser.add_argument("--output", default="parquet/",
+                        help="Where to write the JSON dump of the aggregated DARSHAN logs.")
+    args = parser.parse_args()
+
+    aggregate_darshan(args.directory, args.output, args.debug)

--- a/src/wfmeta_darshan/objs/__init__.py
+++ b/src/wfmeta_darshan/objs/__init__.py
@@ -1,0 +1,1 @@
+from . import colls

--- a/src/wfmeta_darshan/objs/colls.py
+++ b/src/wfmeta_darshan/objs/colls.py
@@ -1,0 +1,177 @@
+import os
+from typing import Dict, List, Tuple
+import pandas as pd
+import logging
+##############################
+# counter-only collections   #
+##############################
+
+class counters_coll :
+    report_name: str
+    report_ids: Dict[str, str]
+    metadata: List[Tuple[int, int]]
+    records: Dict[Tuple[int, int], pd.DataFrame]
+    collapsed: pd.DataFrame
+    module_name: str = "ERR"
+
+    def __init__(self, records, report_name, report_ids) :
+        self.report_name = report_name
+        self.report_ids = report_ids
+        self.metadata = []
+        self.records = {}
+
+        for record in records :
+            record_metadata = (record["rank"], record["id"])
+            # if record_metadata[0] != record["counters"].rank[0] and record_metadata[0] != -1 :
+            #     raise ValueError("Rank of record does not match rank in provided DF.")
+            # if record_metadata[1] != record["counters"].id[0] and record_metadata[1] != -1 :
+            #     raise ValueError("ID of record does not match rank in provided DF.")
+
+            logging.info(record.keys())
+            self.metadata.append(record_metadata)
+            self.records[record_metadata] = record["counters"]
+        
+        self._collapse_rank_id()
+    
+    def _collapse_rank_id(self) :
+        output_df: pd.DataFrame = pd.DataFrame()
+        for i,record in enumerate(self.metadata) :
+            if i == 0 :
+                output_df = self.records[record]
+            else :
+                output_df = pd.concat([output_df, self.records[record]])
+
+        self.collapsed = output_df
+
+    def __add__(self, other: 'counters_coll') -> 'CounterCollColl' :
+        return CounterCollColl(self, other)
+
+
+class LUSTRE_coll(counters_coll) :
+    module_name: str = "LUSTRE"
+
+    def __init__(self, *args) :
+        super().__init__(*args)
+
+    # def export_parquet(self, directory: str, prefix: str) :
+    #     super().export_parquet("LUSTRE", directory, prefix)
+
+##############################
+# two-dataframe      colls   #
+##############################
+
+# e.g. counters & fcounter
+#      DXT_POSIX (read/write)
+
+class fcounters_coll(counters_coll) :
+    module_name: str = "ERR_fcounters"
+    def __init__(self, records, report_name, report_ids):
+        self.report_name = report_name
+        self.report_ids = report_ids
+        # doesn't use super, might want to change it to use it but
+        #   then we're looping over records twice and that's mildly annoying
+        self.metadata = []
+        self.records = {}
+
+        for record in records :
+            record_metadata = (record["rank"], record["id"])
+            self.metadata.append(record_metadata)
+
+            combined: pd.DataFrame = pd.merge(
+                record["counters"], record["fcounters"], "left",
+                ["id","rank"])
+
+            self.records[record_metadata] = combined
+        
+        self._collapse_rank_id()
+
+class STDIO_coll(fcounters_coll) :
+    module_name:str = "STDIO"
+    def __init__(self, *args) :
+        super().__init__(*args)
+
+    # def export_parquet(self, directory: str, prefix: str) :
+    #     super().export_parquet("STDIO", directory, prefix)
+
+class POSIX_coll(fcounters_coll) :
+    module_name:str = "POSIX"
+    def __init__(self, *args) :
+        super().__init__(*args)
+
+    # def export_parquet(self, directory: str, prefix: str) :
+    #     super().export_parquet("POSIX", directory, prefix)
+
+class DXT_POSIX_coll(fcounters_coll) :
+    module_name:str = "DXT_POSIX"
+    def __init__(self, records, report_name, report_ids) :
+        self.report_name = report_name
+        self.report_ids = report_ids
+        self.metadata: List[Tuple[int, str, int, int, int]] = []
+        self.records: Dict[Tuple[int, str, int, int, int], pd.DataFrame]= {}
+
+        for record in records :
+            record_metadata = (record["rank"], str(record["id"]), record["hostname"],
+                                record["write_count"], record["read_count"])
+            self.metadata.append(record_metadata)
+
+            r_df: pd.DataFrame = record['read_segments'].assign(seg_type="read")
+            w_df: pd.DataFrame = record['write_segments'].assign(seg_type="write")
+
+            rw_df: pd.DataFrame = pd.concat([r_df, w_df]).assign(rank=record["rank"], id=str(record["id"]))
+            self.records[record_metadata] = rw_df
+
+        self._collapse_rank_id()
+
+##############################
+# collection collections     #
+##############################
+
+# e.g. collections of collected module information
+#   i.e. sum of all POSIX collections from all records
+#   separates them by their job uid and jobid.
+
+class CounterCollColl :
+    _type: type
+    module_name: str
+    collection: pd.DataFrame
+
+    def __init__(self, left: counters_coll, right: counters_coll) :
+        if type(left) is not type(right) :
+            raise ValueError("Attempted to combine a %s and a %s." % 
+                             (str(type(left)), str(type(right))))
+        
+        self._type = type(left)
+        self.module_name = left.module_name
+        l_df: pd.DataFrame = left.collapsed
+        l_ids = left.report_ids
+        r_df: pd.DataFrame = right.collapsed
+        r_ids = right.report_ids
+
+        # add ids info as columns
+        l_df = l_df.assign(juid=l_ids['juid'], jobid=l_ids['jobid'])
+        r_df = r_df.assign(juid=r_ids['juid'], jobid=r_ids['jobid'])
+
+        self.collection = pd.concat([l_df,r_df])
+
+    def _file_fillers (self, module_name: str):
+        file_prefix = module_name
+        file_suffix = ".parquet"
+        return (file_prefix, file_suffix)
+
+    def export_parquet(self, directory: str, ltype: str = "counters") :
+        file_prefix, file_suffix = self._file_fillers(self.module_name)
+
+        filename = "%s_%s%s" % (file_prefix, ltype, file_suffix)
+        self.collection.to_parquet(os.path.join(directory, filename))
+
+    def __add__(self, other: counters_coll) :
+        if type(other) is not self._type :
+            raise ValueError("Attempted to add a %s to a %s collection" %
+            (str(type(other)), str(self._type)))
+        
+        r_df: pd.DataFrame = other.collapsed
+        r_ids = other.report_ids
+        r_df = r_df.assign(juid=r_ids['juid'], jobid=r_ids['jobid'])
+
+        self.collection = pd.concat([self.collection,r_df])
+        return self

--- a/tests/test_df_concatenation.py
+++ b/tests/test_df_concatenation.py
@@ -1,6 +1,6 @@
 import pytest
 import os
-import darshan_agg
+import wfmeta_darshan as darshan_agg
 import re
 import pandas as pd
 import numpy as np

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,20 @@
+import pytest
+import pathlib
+import os
+from wfmeta_darshan import aggregate_darshan
+
+def test_basic_run(tmpdir):
+    # Just make sure the dang thing runs
+    test_data_dir = pathlib.Path("./tests/test_data/ImageProcessing1")
+    aggregate_darshan(str(test_data_dir), tmpdir, True)
+
+    _, _, files = next(os.walk(tmpdir))
+    print(len(files))
+
+def test_error_on_no_files_found(tmpdir):
+    test_data_dir = pathlib.Path("./tests/test_data")
+
+    with pytest.raises(SystemExit) as pytest_wrapped_e:
+        aggregate_darshan(str(test_data_dir), tmpdir, True)
+    
+    assert pytest_wrapped_e.value.code == 1


### PR DESCRIPTION
Wasn't able to properly continue development because of a lot of references to `write_parquet` that didn't actually exist. Removed these references.

Also restructured code to follow python package structuring better.

Started adding tests.